### PR TITLE
Secure password fix

### DIFF
--- a/_episodes/14-the-spy-game.md
+++ b/_episodes/14-the-spy-game.md
@@ -91,7 +91,7 @@ As it seems like we have a complete CI/CD that does physics - we should see what
 > >   before_script:
 > >     - source /home/atlas/release_setup.sh
 > >     - source build/${AnalysisBase_PLATFORM}/setup.sh
-> >     - echo $SERVICE_PASS | kinit $CERN_USER
+> >     - echo "$SERVICE_PASS" | kinit $CERN_USER
 > >   script:
 > >     - mkdir run
 > >     - cd run


### PR DESCRIPTION
If someone has a special character in their password, such as `!`, the current form does not work. Adding quotes here fixes the issue.